### PR TITLE
überzähligen blank an input_text entfernt

### DIFF
--- a/heizung.php
+++ b/heizung.php
@@ -131,7 +131,7 @@ class SlackTphHeizung {
 
     private function sendComment(string $roomName, string $comment) {
         $this->post('http://hausverstand.iot.fiber.garden:8123/api/services/input_text/set_value', [
-            'entity_id' => 'input_text. ' . $roomName . '_heizkommentar',
+            'entity_id' => 'input_text.' . $roomName . '_heizkommentar',
             'value' => $comment
         ]);
     }


### PR DESCRIPTION
Repariert das Schreiben der Heizkommentare nach Hausverstand.