### PR TITLE
Update config.example.php loetatelier_heizung

### DIFF
--- a/config.example.php
+++ b/config.example.php
@@ -6,7 +6,7 @@ $config = [
         'salon' => 'saloonheizung_saloon_heizung_ein',
         'supermaster_salon_aus' => 'saloonheizung_saloon_heizung_aus',
         'wohnzimmer' => 'heizlufter_wohnzimmer',
-        'atelier' => 'betterthermostat_loet',
-        'loetlabor' => 'betterthermostat_loet',
+        'atelier' => 'loetatelier_heizung',
+        'loetlabor' => 'loetatelier_heizung',
     ]
 ];


### PR DESCRIPTION
Der Schalter für Heizung An/Aus Lötlabor Atelier braucht Umbenennung: Alt: betterthermostat_loet
Neu: loetatelier_heizung

Hier: Anpassung der Mustervorlage